### PR TITLE
Plugin Message Handler: Allows custom dataref registration.

### DIFF
--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -122,6 +122,7 @@ void XPluginReceiveMessage__RegisterDataref(XPLMPluginID inFromWho, intptr_t inM
 	// Decode inParam as C-String.
 	
 	//do a length sanity check.
+	//this could be better - maybe a loop that searches for a null byte in the first 1024 bytes instead of relying on strlen() to do the right thing.
 	long param_string_len = strlen( (char*)inParam );
 	
 	if( param_string_len < 1024 ){
@@ -133,6 +134,7 @@ void XPluginReceiveMessage__RegisterDataref(XPLMPluginID inFromWho, intptr_t inM
 		XPLMDebugString( caDbg );
 		
 		
+		//This code needs unifying with the load-code in datarefs.cpp that also adds resources to "datarefs" vector.
 		XPLMDataRef dr = XPLMFindDataRef(custom_dataref_name.c_str());
 		if(nullptr == dr) {
 			//couldn't find the custom dr as named.

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -4,6 +4,7 @@
 #include "viewer_window.h"
 
 #include "datarefs.h"
+extern std::vector<DataRefRecord> datarefs;
 
 #include "XPWidgets.h"
 #include "XPLMMenus.h"
@@ -86,18 +87,21 @@ void XPluginReceiveMessage__XPlaneMessage(XPLMPluginID inFromWho, intptr_t inMes
 			//This message is sent whenever the user adjusts the number of X-Plane aircraft models. You must use XPLMCountPlanes to find out how many planes are now available. This message will only be sent in XP7 and higher because in XP6 the number of aircraft is not user-adjustable.
 			break;
 
-
 		//SDK 2.00+
 		case XPLM_MSG_PLANE_UNLOADED:
 			//This message is sent to your plugin whenever a plane is unloaded. The parameter is the number of the plane being unloaded; 0 indicates the user's plane.
 			break;
 
 		//SDK 2.1+
-		#if 0
 		case XPLM_MSG_WILL_WRITE_PREFS:
+			//X-Plane is about to quit, probably a good time to write DRT prefs to disk.
+			break;
+			
 		case XPLM_MSG_LIVERY_LOADED:
-		#endif
+			//A new livery has been loaded for the users currently selected aircraft.
+			break;
 		
+		//Unknown
 		default:
 			//Unkown message from X-Plane, do nothing.
 			break;
@@ -127,6 +131,18 @@ void XPluginReceiveMessage__RegisterDataref(XPLMPluginID inFromWho, intptr_t inM
 		
 		sprintf( caDbg, "DRT: Custom Dataref: (%s)\n", custom_dataref_name.c_str() );
 		XPLMDebugString( caDbg );
+		
+		
+		XPLMDataRef dr = XPLMFindDataRef(custom_dataref_name.c_str());
+		if(nullptr == dr) {
+			//couldn't find the custom dr as named.
+			sprintf( caDbg, "DRT: Custom Dataref Invalid: XPLMFindDataRef returns NULL.\n" );
+			XPLMDebugString( caDbg );
+			
+		}else{
+			//add it to our collection.
+			datarefs.emplace_back(custom_dataref_name, dr);
+		}
 		
 	
 	}else{

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -57,5 +57,113 @@ PLUGIN_API int XPluginEnable(void) {
 	return 1;
 }
 
+
+
+
+
+void XPluginReceiveMessage__XPlaneMessage(XPLMPluginID inFromWho, intptr_t inMessage, void * inParam){
+
+	switch( inMessage ){
+		case XPLM_MSG_PLANE_CRASHED:
+			//This message is sent to your plugin whenever the user's plane crashes.
+			break;
+
+		case XPLM_MSG_PLANE_LOADED:
+			//This message is sent to your plugin whenever a new plane is loaded. The parameter is the number of the plane being loaded; 0 indicates the user's plane.
+			if( inParam == 0 ){ //player 1
+			}
+			break;
+
+		case XPLM_MSG_AIRPORT_LOADED:
+			//User has been placed at a new airport.
+			break;
+
+		case XPLM_MSG_SCENERY_LOADED:
+			//This message is sent whenever new scenery is loaded. Use datarefs to determine the new scenery files that were loaded.
+			break;
+
+		case XPLM_MSG_AIRPLANE_COUNT_CHANGED:
+			//This message is sent whenever the user adjusts the number of X-Plane aircraft models. You must use XPLMCountPlanes to find out how many planes are now available. This message will only be sent in XP7 and higher because in XP6 the number of aircraft is not user-adjustable.
+			break;
+
+
+		//SDK 2.00+
+		case XPLM_MSG_PLANE_UNLOADED:
+			//This message is sent to your plugin whenever a plane is unloaded. The parameter is the number of the plane being unloaded; 0 indicates the user's plane.
+			break;
+
+		//SDK 2.1+
+		#if 0
+		case XPLM_MSG_WILL_WRITE_PREFS:
+		case XPLM_MSG_LIVERY_LOADED:
+		#endif
+		
+		default:
+			//Unkown message from X-Plane, do nothing.
+			break;
+	}//end switch(message type)
+
+} //XPluginReceiveMessage__XPlaneMessage(...)
+
+
+
+
+void XPluginReceiveMessage__RegisterDataref(XPLMPluginID inFromWho, intptr_t inMessage, void * inParam){
+
+	char caDbg[2048];
+
+	// Adding support for DRE style custom-dataref registration.
+	// http://www.xsquawkbox.net/xpsdk/mediawiki/Register_Custom_DataRef_in_DRE
+
+	// Decode inParam as C-String.
+	
+	//do a length sanity check.
+	long param_string_len = strlen( (char*)inParam );
+	
+	if( param_string_len < 1024 ){
+	
+		//convert the inParam value to a std::string that gives us the name of the new dataref.
+		std::string custom_dataref_name = std::string( (char*)inParam );
+		
+		sprintf( caDbg, "DRT: Custom Dataref: (%s)\n", custom_dataref_name.c_str() );
+		XPLMDebugString( caDbg );
+		
+	
+	}else{
+		XPLMDebugString("DRT: Custom Dataref rejected. Name is extremely long.\n");
+	}
+
+
+} //XPluginReceiveMessage__RegisterDataref(...)
+
+
+
+
+// Some inMessage values that we want to respond to.
+#define DRE_MSG_ADD_DATAREF 0x01000000           //  Add dataref to DRE message
+
+
 PLUGIN_API void XPluginReceiveMessage(XPLMPluginID inFromWho, intptr_t inMessage, void * inParam) {
-}
+
+	char caDbg[2048];
+	
+
+	if( XPLM_PLUGIN_XPLANE == inFromWho ){
+	
+		//Filter for X-Plane as sender. Some messages are best ignored if from random XPL client.
+		XPluginReceiveMessage__XPlaneMessage( inFromWho, inMessage, inParam );
+		
+	}else{
+		switch( inMessage ){
+			case DRE_MSG_ADD_DATAREF:
+				XPluginReceiveMessage__RegisterDataref( inFromWho, inMessage, inParam );
+				break;
+	
+			default:
+				sprintf( caDbg, "DRT: Unknown XPL message. (From:%i) (Type:%i)\n", 1,2 );
+				XPLMDebugString( caDbg );
+	
+		} //switch( inMessage )
+	}
+
+} //XPluginReceiveMessage(...)

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -94,7 +94,7 @@ void XPluginReceiveMessage__XPlaneMessage(XPLMPluginID inFromWho, intptr_t inMes
 
 		//SDK 2.1+
 		case XPLM_MSG_WILL_WRITE_PREFS:
-			//X-Plane is about to quit, probably a good time to write DRT prefs to disk.
+			//TODO: X-Plane is about to quit, probably a good time to write DRT prefs to disk.
 			break;
 			
 		case XPLM_MSG_LIVERY_LOADED:
@@ -122,7 +122,7 @@ void XPluginReceiveMessage__RegisterDataref(XPLMPluginID inFromWho, intptr_t inM
 	// Decode inParam as C-String.
 	
 	//do a length sanity check.
-	//this could be better - maybe a loop that searches for a null byte in the first 1024 bytes instead of relying on strlen() to do the right thing.
+	//TODO: This could be better - maybe a loop that searches for a null byte in the first 1024 bytes instead of relying on strlen() to do the right thing?
 	long param_string_len = strlen( (char*)inParam );
 	
 	if( param_string_len < 1024 ){
@@ -134,7 +134,7 @@ void XPluginReceiveMessage__RegisterDataref(XPLMPluginID inFromWho, intptr_t inM
 		XPLMDebugString( caDbg );
 		
 		
-		//This code needs unifying with the load-code in datarefs.cpp that also adds resources to "datarefs" vector.
+		//TODO: This code needs unifying with the load-code in datarefs.cpp that also adds resources to "datarefs" vector.
 		XPLMDataRef dr = XPLMFindDataRef(custom_dataref_name.c_str());
 		if(nullptr == dr) {
 			//couldn't find the custom dr as named.
@@ -178,10 +178,11 @@ PLUGIN_API void XPluginReceiveMessage(XPLMPluginID inFromWho, intptr_t inMessage
 				break;
 	
 			default:
-				sprintf( caDbg, "DRT: Unknown XPL message. (From:%i) (Type:%i)\n", 1,2 );
+				sprintf( caDbg, "DRT: Unknown XPL message. (From:%ld) (Type:%ld)\n", (long)inFromWho, inMessage );
 				XPLMDebugString( caDbg );
 	
 		} //switch( inMessage )
-	}
+		
+	} //test if from x-plane or XPL
 
 } //XPluginReceiveMessage(...)


### PR DESCRIPTION
Adds plugin message handler code that is compatible with DRE "custom dataref registration" message format.

Please note, contains minor TODO items at lines: 97, 125, 137


Plugins sending registation messages need to change their code to send a broadcast message instead of a targeted message.

Eg:
XPLMSendMessageToPlugin( XPLM_NO_PLUGIN_ID, 0x01000000, (void*)"custom/dataref" );

Sending to XPLM_NO_PLUGIN_ID sends as message broadcast.